### PR TITLE
add probes for load balancer health checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 0.2.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add probes for load balancer health-checks
+  [fRiSi]
 
 
 0.2.5 (2016-02-25)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -2,3 +2,5 @@ Note:  place names and roles of the people who contribute to this package
        in this file, one to a line, like so:
 
 - Benoît Suttor <bsuttor@imio.be>, Original Author
+
+- Harald Friessnegger (Webmeisterei GmbH)

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Probes
 Currently supported probes:
 
 - cache_size -- cache sizes informations
-- check_smtp -- Check if SMTP is initialize, return number of errors found. 
+- check_smtp -- Check if SMTP is initialize, return number of errors found.
 - check_upgrade_steps -- Check if all upgrade steps are ran.
 - conflictcount -- number of all conflict errors since startup
 - count_users -- the total amount of users in your plone site
@@ -45,6 +45,8 @@ Currently supported probes:
 - dbinfo -- Get database statistics
 - dbsize -- size of the database (default=main) in bytes
 - errorcount -- number of error present in error_log (default in the root).
+- health_ok -- fast health check for load balancers that simply returns 'OK'
+- health_db_connected  -- returns the string 'OK' if database is connected. (default=main)
 - help -- Get help about server commands
 - interactive -- Turn on monitor's interactive mode
 - last_login_time -- Get last login time user. Default return unix_time (defaut=True) if you want ISO time call 'False' attr.
@@ -70,7 +72,7 @@ How it works
 This package use differents package
 
 - five.z2monitor
-- Products.ZNagios 
+- Products.ZNagios
 - munin.zope
 - zc.z3monitor
 - zc.monitorcache

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Currently supported probes:
 - dbsize -- size of the database (default=main) in bytes
 - errorcount -- number of error present in error_log (default in the root).
 - health_ok -- fast health check for load balancers that simply returns 'OK'
-- health_db_connected  -- returns the string 'OK' if database is connected. (default=main)
+- health_db_connected  -- returns the string 'OK' if database (default=main) is connected.
 - help -- Get help about server commands
 - interactive -- Turn on monitor's interactive mode
 - last_login_time -- Get last login time user. Default return unix_time (defaut=True) if you want ISO time call 'False' attr.

--- a/collective/monitor/configure.zcml
+++ b/collective/monitor/configure.zcml
@@ -14,7 +14,7 @@
     <utility
         component=".threads.threads"
         provides="zc.z3monitor.interfaces.IZ3MonitorPlugin"
-        name="threads" 
+        name="threads"
         />
 
     <utility
@@ -77,4 +77,15 @@
         name="eggs"
         />
 
+    <utility
+        component=".health.ok"
+        provides="zc.z3monitor.interfaces.IZ3MonitorPlugin"
+        name="health_ok"
+        />
+
+    <utility
+        component=".health.db_connected"
+        provides="zc.z3monitor.interfaces.IZ3MonitorPlugin"
+        name="health_db_connected"
+        />
 </configure>

--- a/collective/monitor/health.py
+++ b/collective/monitor/health.py
@@ -1,0 +1,21 @@
+from Zope2 import app as App
+
+
+def ok(connection):
+    """Very simple probe that returns the string 'OK'.
+    can be used for health checks in load-balancers
+    """
+    connection.write('OK\n')
+
+def db_connected(connection, dbname='main'):
+    """returns the string 'OK' if database (default=main) is connected.
+    can be used for health checks in load-balancers
+    """
+    app = App()
+    try:
+        if app.Control_Panel.Database[dbname]._getDB()._storage.is_connected():
+            connection.write('OK\n')
+            return
+        connection.write('database {} is not connected\n'.format(dbname))
+    except KeyError, e:
+        connection.write(str(e))

--- a/collective/monitor/health.py
+++ b/collective/monitor/health.py
@@ -2,8 +2,7 @@ from Zope2 import app as App
 
 
 def ok(connection):
-    """Very simple probe that returns the string 'OK'.
-    can be used for health checks in load-balancers
+    """fast health check for load balancers that simply returns 'OK'
     """
     connection.write('OK\n')
 


### PR DESCRIPTION
see http://hvelarde.blogspot.co.at/2017/12/configuring-better-load-balancing-and.html for details how to set this up for haproxy

```
option tcp-check
tcp-check send health_db_connected\r\n
tcp-check expect string OK

default-server maxconn 4 inter 2s slowstart 1m

server instance1 127.0.0.1:8081 check port 8881
```